### PR TITLE
Fix Go version is wrapped in 'single quote'

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20
+        go-version: '1.20'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
YAMLのパース時に末尾の0が切り捨てられGoのバージョンが1.2になってしまうことの防止。